### PR TITLE
Run satdump in sudo 

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -42,7 +42,7 @@ WXMAP="/usr/local/bin/wxmap"
 WXTOIMG="/usr/local/bin/wxtoimg"
 WKHTMLTOIMG="/usr/bin/wkhtmltoimage"
 METEORDEMOD="/usr/local/bin/meteordemod"
-SATDUMP="/usr/bin/satdump"
+SATDUMP="sudo /usr/bin/satdump"
 
 # base directories for scripts
 SCRIPTS_DIR="${NOAA_HOME}/scripts"


### PR DESCRIPTION
Without **sudo**, **satdump** show this error : `cannot create directories: Permission denied [/home/[USER]/.config/satdump`
So, no **TLE** can be loaded and the capture generated look like this :
<img width="1130" alt="Screenshot 2024-04-24 at 8 42 38 AM" src="https://github.com/pichu314/raspberry-noaa-v2/assets/112083511/1b59626f-af55-448b-8624-ed1099bf662c">

